### PR TITLE
Add Flutter port skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@
   http://nvie.com/posts/a-successful-git-branching-model/
   
     Author: Juan Del Boca
+
+## Flutter port
+
+A minimal Flutter implementation is available in `spitball_flutter/`.
+It uses the [Flame](https://flame-engine.org/) game engine to render
+the board and manage input. This is an experimental port of the core
+Java logic to Dart.

--- a/spitball_flutter/README.md
+++ b/spitball_flutter/README.md
@@ -1,0 +1,19 @@
+# SpitBall Flutter
+
+This directory contains a simple Flutter/Flame implementation of the
+original SpitBall game logic.  It uses `GameWidget` from the `flame`
+package to render a board and handle user input.
+
+The implementation mirrors the Java engine with Dart classes for
+`GameManager`, `Tile`, and the various `Ball` types. Only a subset of
+the original features is provided as a starting point for a full
+migration.
+
+To run the game you need Flutter installed:
+
+```bash
+flutter run
+```
+
+This is only a skeleton intended to demonstrate how the Android game
+could be migrated to Flutter.

--- a/spitball_flutter/lib/game/ai_algorithm.dart
+++ b/spitball_flutter/lib/game/ai_algorithm.dart
@@ -1,0 +1,40 @@
+import 'dart:math';
+
+import 'ball_green.dart';
+import 'ball_pink.dart';
+import 'game_manager.dart';
+import 'tile.dart';
+
+class AIAlgorithm {
+  static final _rand = Random();
+
+  static List<int> randomMove(List<List<Tile>> tiles) {
+    final coords = _randomBall(tiles);
+    int y = coords[0];
+    int x = coords[1];
+
+    int dy = _rand.nextBool() ? 1 : -1;
+    int dx = _rand.nextBool() ? 1 : -1;
+
+    int newY = y + dy;
+    int newX = x + dx;
+
+    if (newY >= 0 && newY < GameManager.height && newX >= 0 && newX < GameManager.width) {
+      return [y, x, newY, newX, 0];
+    } else {
+      return randomMove(tiles);
+    }
+  }
+
+  static List<int> _randomBall(List<List<Tile>> tiles) {
+    final positions = <List<int>>[];
+    for (var i = 0; i < GameManager.height; i++) {
+      for (var j = 0; j < GameManager.width; j++) {
+        if (tiles[i][j].ball is BallPink) {
+          positions.add([i, j]);
+        }
+      }
+    }
+    return positions[_rand.nextInt(positions.length)];
+  }
+}

--- a/spitball_flutter/lib/game/ball.dart
+++ b/spitball_flutter/lib/game/ball.dart
@@ -1,0 +1,5 @@
+class Ball {
+  int size;
+
+  Ball(this.size);
+}

--- a/spitball_flutter/lib/game/ball_green.dart
+++ b/spitball_flutter/lib/game/ball_green.dart
@@ -1,0 +1,5 @@
+import 'ball.dart';
+
+class BallGreen extends Ball {
+  BallGreen(int size) : super(size);
+}

--- a/spitball_flutter/lib/game/ball_pink.dart
+++ b/spitball_flutter/lib/game/ball_pink.dart
@@ -1,0 +1,5 @@
+import 'ball.dart';
+
+class BallPink extends Ball {
+  BallPink(int size) : super(size);
+}

--- a/spitball_flutter/lib/game/ball_type.dart
+++ b/spitball_flutter/lib/game/ball_type.dart
@@ -1,0 +1,4 @@
+enum BallType {
+  green,
+  pink,
+}

--- a/spitball_flutter/lib/game/game_manager.dart
+++ b/spitball_flutter/lib/game/game_manager.dart
@@ -1,0 +1,138 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import 'ball.dart';
+import 'ball_green.dart';
+import 'ball_pink.dart';
+import 'tile.dart';
+import 'ball_type.dart';
+import 'ai_algorithm.dart';
+
+class GameManager {
+  static const int width = 10;
+  static const int height = 6;
+
+  final List<List<Tile>> tiles =
+      List.generate(height, (_) => List.generate(width, (_) => Tile()));
+
+  int playerTurn = 0;
+  int clicks = 0;
+  int? initialX;
+  int? initialY;
+  bool gameOver = false;
+
+  GameManager() {
+    _initialize();
+  }
+
+  void _initialize() {
+    tiles[1][3].ball = BallGreen(20);
+    tiles[2][2].ball = BallGreen(20);
+    tiles[3][3].ball = BallGreen(20);
+    tiles[1][5].ball = BallPink(20);
+    tiles[2][6].ball = BallPink(20);
+    tiles[3][5].ball = BallPink(20);
+  }
+
+  void render(Canvas canvas, Size size) {
+    final cellWidth = size.width / width;
+    final cellHeight = size.height / height;
+    final paint = Paint()..color = Colors.black;
+
+    for (var y = 0; y < height; y++) {
+      for (var x = 0; x < width; x++) {
+        final rect = Rect.fromLTWH(
+          x * cellWidth,
+          y * cellHeight,
+          cellWidth,
+          cellHeight,
+        );
+        canvas.drawRect(rect, paint..style = PaintingStyle.stroke);
+        final ball = tiles[y][x].ball;
+        if (ball.size > 0) {
+          final color = ball is BallGreen ? Colors.green : Colors.pink;
+          final radius = (ball.size.toDouble() / 40) *
+              (cellWidth < cellHeight ? cellWidth / 2 : cellHeight / 2);
+          canvas.drawCircle(rect.center, radius, Paint()..color = color);
+        }
+      }
+    }
+  }
+
+  void handleTap(Offset pos) {
+    final c = _posToCoord(pos);
+    if (c == null) return;
+    _processTap(c[1], c[0]);
+  }
+
+  void startDrag(Offset pos) {
+    final c = _posToCoord(pos);
+    if (c != null) {
+      _processTap(c[1], c[0]);
+    }
+  }
+
+  void updateDrag(Offset pos) {}
+
+  void endDrag() {
+    clicks = 0;
+  }
+
+  List<int>? _posToCoord(Offset pos) {
+    final cellWidth = gameSize!.width / width;
+    final cellHeight = gameSize!.height / height;
+    final x = (pos.dx / cellWidth).floor();
+    final y = (pos.dy / cellHeight).floor();
+    if (x >= 0 && x < width && y >= 0 && y < height) {
+      return [y, x];
+    }
+    return null;
+  }
+
+  Size? gameSize;
+
+  void move(int fromY, int fromX, int toY, int toX) {
+    final moved = tiles[toY][toX].battle(tiles[fromY][fromX].ball, false);
+    if (moved) {
+      tiles[fromY][fromX].ball = Ball(0);
+      playerTurn = (playerTurn + 1) % 2;
+    }
+  }
+
+  void split(int fromY, int fromX, int toY, int toX) {
+    final ball = tiles[fromY][fromX].ball;
+    if (ball.size < 10) return;
+    final splittedSize = ball.size ~/ 3;
+    Ball splitted;
+    if (ball is BallPink) {
+      splitted = BallPink((splittedSize * 1.2).floor());
+    } else {
+      splitted = BallGreen((splittedSize * 1.2).floor());
+    }
+    ball.size -= splittedSize;
+    tiles[toY][toX].battle(splitted, false);
+    playerTurn = (playerTurn + 1) % 2;
+  }
+
+  void _processTap(int x, int y) {
+    if (clicks == 0) {
+      initialX = x;
+      initialY = y;
+      clicks = 1;
+    } else if (clicks == 1) {
+      if (initialX == x && initialY == y) {
+        clicks = 0;
+      } else if ((initialX! - x).abs() <= 1 && (initialY! - y).abs() <= 1) {
+        move(initialY!, initialX!, y, x);
+        clicks = 0;
+      } else if ((initialX! - x).abs() == 2 && initialY == y ||
+          (initialY! - y).abs() == 2 && initialX == x) {
+        split(initialY!, initialX!, y, x);
+        clicks = 0;
+      } else {
+        clicks = 0;
+      }
+    }
+  }
+}

--- a/spitball_flutter/lib/game/spitball_game.dart
+++ b/spitball_flutter/lib/game/spitball_game.dart
@@ -1,0 +1,45 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
+import 'package:flame/game.dart';
+import 'package:flutter/material.dart';
+
+import 'game_manager.dart';
+
+class SpitBallGame extends FlameGame with TapDetector, PanDetector {
+  const SpitBallGame();
+
+  final GameManager _manager = GameManager();
+
+  @override
+  Future<void> onLoad() async {
+    camera.viewport = FixedResolutionViewport(Vector2(800, 480));
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    _manager.render(canvas, size);
+  }
+
+  @override
+  void onTapUp(TapUpInfo info) {
+    _manager.handleTap(info.eventPosition.game);
+  }
+
+  @override
+  void onPanEnd(DragEndInfo info) {
+    _manager.endDrag();
+  }
+
+  @override
+  void onPanStart(DragStartInfo info) {
+    _manager.startDrag(info.eventPosition.game);
+  }
+
+  @override
+  void onPanUpdate(DragUpdateInfo info) {
+    _manager.updateDrag(info.eventPosition.game);
+  }
+}

--- a/spitball_flutter/lib/game/tile.dart
+++ b/spitball_flutter/lib/game/tile.dart
@@ -1,0 +1,25 @@
+import 'ball.dart';
+import 'ball_green.dart';
+import 'ball_pink.dart';
+
+class Tile {
+  Ball ball = Ball(0);
+
+  bool battle(Ball immigrant, bool limited) {
+    if ((immigrant is BallGreen && ball is BallGreen && limited) ||
+        (immigrant is BallPink && ball is BallPink && limited)) {
+      return false;
+    }
+
+    if (immigrant.size >= ball.size) {
+      if (immigrant is BallGreen) {
+        ball = BallGreen(ball.size + immigrant.size);
+      } else {
+        ball = BallPink(ball.size + immigrant.size);
+      }
+    } else {
+      ball.size += immigrant.size;
+    }
+    return true;
+  }
+}

--- a/spitball_flutter/lib/main.dart
+++ b/spitball_flutter/lib/main.dart
@@ -1,0 +1,8 @@
+import 'package:flame/game.dart';
+import 'package:flutter/material.dart';
+
+import 'game/spitball_game.dart';
+
+void main() {
+  runApp(const GameWidget(game: SpitBallGame()));
+}

--- a/spitball_flutter/pubspec.yaml
+++ b/spitball_flutter/pubspec.yaml
@@ -1,0 +1,18 @@
+name: spitball_flutter
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flame: ^1.8.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a minimal Flutter implementation in `spitball_flutter`
- port core engine classes from Java to Dart
- document running the Flutter version

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848201873948320859dd3c85a6460eb